### PR TITLE
Replace Some/None usage with Option.

### DIFF
--- a/src/main/scala/Iter2.scala
+++ b/src/main/scala/Iter2.scala
@@ -8,18 +8,12 @@ object Iter2{
   
   def enumFromFile(path:String) = {
     val r = new java.io.BufferedReader( new java.io.FileReader(path))
-    
-    Enumerator.fromCallback1( b => {
-      val line = r.readLine
-      val chunk = if(line == null) None else Some(line)
-      scala.concurrent.Future.successful(chunk)
-    }, r.close			     )
+    Enumerator.fromCallback1(b => Future.successful(Option(r.readLine)), r.close)
   }
 
   val intMapper = Enumeratee.map( (x:String) => x.toInt)
 
   val sum = Iteratee.fold(0)((x:Int, y:Int) => x + y)
-
 
   //lazy val res = e |>>> toInt &>> sum
   


### PR DESCRIPTION
`if (x == null) Some(x) else None` expression is equivalent to `Option(x)`. In addition, due to `scala.concurrent._` import, `scala.concurrent.Future` usage is redundant.
